### PR TITLE
Remove service: dev from app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -14,7 +14,6 @@
 
 runtime: go
 api_version: go1
-service: dev
 
 handlers:
 - url: /.*


### PR DESCRIPTION
So that we can deploy directly to wptdashboard.appspot.com