### PR TITLE
Serve complete run by default

### DIFF
--- a/webapp/test_handler.go
+++ b/webapp/test_handler.go
@@ -53,7 +53,7 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf(singleRunURL, after.Revision, after.Platform),
 		}
 	} else {
-		const sourceURL = `/api/runs?sha=%s`
+		const sourceURL = `/api/runs?sha=%s&complete=true`
 		testRunSources = []string{fmt.Sprintf(sourceURL, runSHA)}
 	}
 


### PR DESCRIPTION
For [ the Q1 KR](https://docs.google.com/document/d/1ojlLDiRruI4e95Z7JQ10JQPRMiQHd_40rBkYCL6IJqw/edit#heading=h.2nhv4te6hv4x)

Don't merge this until the runs are consistently complete.