### PR TITLE
Add HSTS header to every request

### DIFF
--- a/webapp/main.go
+++ b/webapp/main.go
@@ -12,7 +12,7 @@ import (
 var templates = template.Must(template.ParseGlob("templates/*.html"))
 
 func init() {
-	routes := map[string]http.HandlerFunc {
+	routes := map[string]http.HandlerFunc{
 		// Test run results, viewed by browser (default view)
 		// For run results diff view, 'before' and 'after' params can be given.
 		"/": testHandler,

--- a/webapp/main_test.go
+++ b/webapp/main_test.go
@@ -18,6 +18,10 @@ func TestLandingPageBound(t *testing.T) {
 	assertHandlerMatch(t, "/2dcontext", "/")
 }
 
+func TestLandingPageHSTS(t *testing.T) {
+	assertHSTS(t, "/")
+}
+
 func TestAboutBound(t *testing.T) {
 	assertBound(t, "/about")
 	assertHandlerMatch(t, "/about", "/about")
@@ -41,6 +45,10 @@ func TestInteropAnomaliesBound(t *testing.T) {
 
 func TestRunsBound(t *testing.T) {
 	assertBound(t, "/test-runs")
+}
+
+func TestRunsBoundHSTS(t *testing.T) {
+	assertHSTS(t, "/test-runs")
 }
 
 func TestApiDiffBound(t *testing.T) {
@@ -70,4 +78,14 @@ func assertHandlerMatch(t *testing.T, path string, pattern string) {
 	handler, handlerPattern := http.DefaultServeMux.Handler(req)
 	assert.NotNil(t, handler)
 	assert.Equal(t, pattern, handlerPattern)
+}
+
+
+func assertHSTS(t *testing.T, path string) {
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	handler, _ := http.DefaultServeMux.Handler(req)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, "max-age=31536000; includeSubDomains; preload",
+		rr.HeaderMap["Strict-Transport-Security"][0])
 }

--- a/webapp/main_test.go
+++ b/webapp/main_test.go
@@ -81,7 +81,7 @@ func assertHandlerMatch(t *testing.T, path string, pattern string) {
 }
 
 func assertHSTS(t *testing.T, path string) {
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", path, nil)
 	rr := httptest.NewRecorder()
 	handler, _ := http.DefaultServeMux.Handler(req)
 	handler.ServeHTTP(rr, req)

--- a/webapp/main_test.go
+++ b/webapp/main_test.go
@@ -80,7 +80,6 @@ func assertHandlerMatch(t *testing.T, path string, pattern string) {
 	assert.Equal(t, pattern, handlerPattern)
 }
 
-
 func assertHSTS(t *testing.T, path string) {
 	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
This adds an HSTS header to every request that expires after 1 year.
It also applies the rule to all subdomains (we should check if this is
feasible) and opts-in to the HSTS preload list.

I'm not sure what the deploy process is like these days  but let me know how I can be of help getting this to production.

Resolves #128 