### PR TITLE
Formally manage Google Cloud Platform inventory

### DIFF
--- a/provisioning/infrastructure/.gitignore
+++ b/provisioning/infrastructure/.gitignore
@@ -1,2 +1,3 @@
 *.plan
 /.terraform/
+/google-cloud-platform.json

--- a/provisioning/infrastructure/README.md
+++ b/provisioning/infrastructure/README.md
@@ -6,6 +6,10 @@
 2. Ensure `~/.aws/credentials` has an entry with administrative access keys
    matching the `profile` for the project. The profile name can be found in
    `terraform/{project}/variables.tf` under the `provider "aws" {}` block.
+3. Retrieve a Google Cloud Platform credentials file and save it with the file
+   name `google-cloud-platform.json` in the current directory. [Instructions
+   are available
+   here.](https://www.terraform.io/docs/providers/google/index.html)
 
 ### Commands Available
 

--- a/provisioning/infrastructure/storage.tf
+++ b/provisioning/infrastructure/storage.tf
@@ -6,3 +6,28 @@ resource "aws_ebs_volume" "build_master_database" {
     "Name" = "${var.name}-build-master-database"
   }
 }
+
+# The results collector uploads JSON-formatted WPT results to this bucket. The
+# https://wpt.fyi website currently retrieves files from this bucket directly,
+# necessitating CORS support.
+resource "google_storage_bucket" "results_store" {
+  name = "wptd"
+  location = "US"
+  storage_class = "MULTI_REGIONAL"
+
+  cors {
+    max_age_seconds = 86400
+    origin = ["*"]
+    method = ["GET", "HEAD"]
+  }
+}
+
+# The results collector installs experimental browser builds prior to
+# collecting results. In order to ensure failed collection attempts can be
+# re-tried at a later date (even after new browser builds have been published),
+# it uses the following bucket as a mirror for the installation artifacts.
+resource "google_storage_bucket" "browser_store" {
+  name = "browsers"
+  location = "US"
+  storage_class = "MULTI_REGIONAL"
+}

--- a/provisioning/infrastructure/variables.tf
+++ b/provisioning/infrastructure/variables.tf
@@ -26,6 +26,11 @@ provider "aws" {
   region = "us-east-1"
 }
 
+provider "google" {
+  project = "wptdashboard"
+  credentials = "${file("google-cloud-platform.json")}"
+}
+
 ##
 # This tells Terraform where to persist the state of the infrastructure for
 # this project. We use S3 so the state doesn't have to be manually checked

--- a/src/master/master.cfg
+++ b/src/master/master.cfg
@@ -35,6 +35,8 @@ total_chunks = {
     'slow': 100,
     'fast': 20
 }
+# The following object stores are defined via this project's Terraform
+# configuration.
 buckets = {
     'results': 'wptd',
     'browsers': 'browsers'


### PR DESCRIPTION
Extend the project's Terraform configuration with descriptions of the
required object stores as provided by Google Cloud Platform.

@lukebjerring @hexcles I wanted to give you a heads-up about this. As long as
the results collector is uploading directly to the "wpt" bucket and providing
public URLs to wpt.fyi, I think it makes sense to manage its configuration
here. We won't be in this state for long, though. Once the runner is reporting
to a collector (as per Robert's diagramming on Monday), the "wpt" bucket will
become the collector's responsibility, and we can remove its entry in this
project's configuration.

In the mean time, if any changes are necessary, please make them here so that
I don't accidentally revert them while deploying.