### PR TITLE
Report on any incomplete result sets

### DIFF
--- a/src/scripts/validate-wpt-results.py
+++ b/src/scripts/validate-wpt-results.py
@@ -8,8 +8,6 @@ import argparse
 import json
 import logging
 
-THRESHOLD = 0.02
-
 
 def main(log_wptreport, log_raw):
     '''Verify that the test results for a trial of the Web Platform Tests (as
@@ -49,15 +47,7 @@ def main(log_wptreport, log_raw):
     annotate(log_wptreport, len(expected_results), len(unexpected_results),
              len(missing_results))
 
-    # Due to the way tests are segmented (i.e. the WPT CLI's "chunk"
-    # functionality), a results set may be empty. If the "raw" log describes
-    # this state, then an empty results set should be accepted.
-    if total_expected == 0:
-        assert total_incorrect == 0
-    else:
-        assert float(total_incorrect) / total_expected < THRESHOLD, (
-            'Percentage of incorrect results exceeded threshold'
-        )
+    assert total_incorrect == 0
 
 
 def normalize_wpt_report(log_wptreport):

--- a/test/validate_wpt_results_test.py
+++ b/test/validate_wpt_results_test.py
@@ -168,7 +168,7 @@ class ValidateWptResults(unittest.TestCase):
         self.assertCompleteness(log_wptreport, total_expected=0,
                                 total_unexpected=6, total_missing=0)
 
-    def test_missing_acceptable(self):
+    def test_missing(self):
         results, filenames = make_results(100)
         log_wptreport = self.temp_file('wpt-log.json')
         log_raw = self.temp_file('raw-log.json')
@@ -190,40 +190,12 @@ class ValidateWptResults(unittest.TestCase):
 
         returncode, stdout, stderr = self.validate(log_wptreport, log_raw)
 
-        self.assertEquals(returncode, 0, stderr)
+        self.assertEquals(returncode, 1, stdout)
 
         self.assertCompleteness(log_wptreport, total_expected=100,
                                 total_unexpected=0, total_missing=1)
 
-    def test_missing_unacceptable(self):
-        results, filenames = make_results(100)
-        log_wptreport = self.temp_file('wpt-log.json')
-        log_raw = self.temp_file('raw-log.json')
-
-        del results['results'][23]
-        del results['results'][45]
-
-        with open(log_wptreport, 'w') as handle:
-            json.dump(results, handle)
-
-        with open(log_raw, 'w') as handle:
-            handle.write(
-                json.dumps({
-                    'action': 'suite_start',
-                    'tests': {
-                        'default': filenames
-                    }
-                })
-            )
-
-        returncode, stdout, stderr = self.validate(log_wptreport, log_raw)
-
-        self.assertEquals(returncode, 1, stdout)
-
-        self.assertCompleteness(log_wptreport, total_expected=100,
-                                total_unexpected=0, total_missing=2)
-
-    def test_extra_acceptable(self):
+    def test_extra(self):
         results, filenames = make_results(100)
         log_wptreport = self.temp_file('wpt-log.json')
         log_raw = self.temp_file('raw-log.json')
@@ -245,35 +217,7 @@ class ValidateWptResults(unittest.TestCase):
 
         returncode, stdout, stderr = self.validate(log_wptreport, log_raw)
 
-        self.assertEquals(returncode, 0, stderr)
+        self.assertEquals(returncode, 1, stdout)
 
         self.assertCompleteness(log_wptreport, total_expected=99,
                                 total_unexpected=1, total_missing=0)
-
-    def test_extra_unacceptable(self):
-        results, filenames = make_results(100)
-        log_wptreport = self.temp_file('wpt-log.json')
-        log_raw = self.temp_file('raw-log.json')
-
-        del filenames[33]
-        del filenames[66]
-
-        with open(log_wptreport, 'w') as handle:
-            json.dump(results, handle)
-
-        with open(log_raw, 'w') as handle:
-            handle.write(
-                json.dumps({
-                    'action': 'suite_start',
-                    'tests': {
-                        'default': filenames
-                    }
-                })
-            )
-
-        returncode, stdout, stderr = self.validate(log_wptreport, log_raw)
-
-        self.assertEquals(returncode, 1, stdout)
-
-        self.assertCompleteness(log_wptreport, total_expected=98,
-                                total_unexpected=2, total_missing=0)


### PR DESCRIPTION
Previously, datasets which omitted results for some tests were
considered acceptable and subsequently uploaded to the web. The
underlying issues which motivated that design have been resolved, so the
project may be in a position to reject any incomplete datasets.

However, due to the imprecise nature of the previous validation
strategy, the actual completeness levels for certain browser
configurations are not well understood. Specifically, reports for
browsers which are mediated by the Sauce Labs service may continue to be
incomplete.

Decrease the threshold for missing tests to zero percent during results
validation. Maintain the prior threshold of two percent during results
uploading.

This configuration will surface any persisting issues with
incompleteness in the build system's web interface without interfering
with the overall reporting behavior. In this way, project maintainers
can verify that missing results are now a truly anomalous case, and a
subsequent commit can reject such datasets outright.