### PR TITLE
Disable autoplay policy enforcement in Chrome

### DIFF
--- a/src/master/wpt_run_step.py
+++ b/src/master/wpt_run_step.py
@@ -83,7 +83,10 @@ class WptRunStep(steps.ShellCommand):
             # Chrome to call getUserMedia without failing out.
             command.extend([
                 '--binary-arg=--use-fake-ui-for-media-stream',
-                '--binary-arg=--use-fake-device-for-media-stream'
+                '--binary-arg=--use-fake-device-for-media-stream',
+                # See
+                # https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
+                '--binary-arg=--autoplay-policy=no-user-gesture-required'
             ])
 
         command.append(browser_id)


### PR DESCRIPTION
Recent changes in the Chrome browser's policy for media "autoplay" [1]
have implications for automated tests. At least 84 tests that were
previously known to pass in automated scenarios now fail with error
messages like:

> play() failed because the user didn't interact with the document
> first.  https://goo.gl/xX8pDD

Extend the invocation of the Chrome browser with a flag which is
purported to disable this feature [2].

[1] https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
[2] https://peter.sh/experiments/chromium-command-line-switches/#no-user-gesture-required

---

Hi @beaufortfrancois! I'd like to avoid regressing with future releases of Chrome; do you know of a canonical source documenting the `--autoplay-policy` command-line option?

<details>
  <summary>Listing of the 84 ests effected by policy change</summary>

These tests were identified by searching results data for references to
"https://goo.gl/xX8pDD"

- mediacapture-fromelement/creation.html
- mediacapture-fromelement/ended.html
- mediacapture-fromelement/capture.html
- media-source/mediasource-redundant-seek.html
- media-source/mediasource-play-then-seek-back.html
- media-source/mediasource-seek-during-pending-seek.html
- media-source/mediasource-duration.html
- media-source/mediasource-play.html
- media-source/mediasource-seek-beyond-duration.html
- webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html
- encrypted-media/drm-mp4-setmediakeys-again-after-resetting-src.https.html
- encrypted-media/drm-mp4-waiting-for-a-key.https.html
- encrypted-media/drm-mp4-playback-temporary-encrypted-clear-sources.https.html
- encrypted-media/drm-mp4-playback-temporary-setMediaKeys-after-update.https.html
- encrypted-media/clearkey-mp4-playback-temporary-events.https.html
- encrypted-media/drm-mp4-playback-temporary-clear-encrypted.https.html
- encrypted-media/drm-mp4-playback-temporary.https.html
- encrypted-media/drm-mp4-playback-temporary-multikey-sequential.https.html
- encrypted-media/drm-mp4-playback-temporary-two-videos.https.html
- encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear-sources.https.html
- encrypted-media/clearkey-mp4-setmediakeys-again-after-resetting-src.https.html
- encrypted-media/drm-mp4-setmediakeys-again-after-playback.https.html
- encrypted-media/drm-mp4-playback-temporary-multikey.https.html
- encrypted-media/clearkey-mp4-playback-temporary-multikey-sequential.https.html
- encrypted-media/clearkey-mp4-playback-temporary-waitingforkey.https.html
- encrypted-media/clearkey-mp4-playback-temporary-multikey.https.html
- encrypted-media/drm-mp4-playback-temporary-setMediaKeys-after-src.https.html
- encrypted-media/clearkey-mp4-playback-temporary-setMediaKeys-onencrypted.https.html
- encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear.https.html
- encrypted-media/clearkey-mp4-playback-temporary-setMediaKeys-after-src.https.html
- encrypted-media/clearkey-mp4-playback-temporary-multikey-sequential-readyState.https.html
- encrypted-media/clearkey-mp4-playback-temporary-multisession.https.html
- encrypted-media/drm-mp4-playback-temporary-encrypted-clear.https.html
- encrypted-media/clearkey-mp4-waiting-for-a-key.https.html
- encrypted-media/drm-mp4-playback-temporary-multikey-sequential-readyState.https.html
- encrypted-media/clearkey-mp4-playback-temporary-two-videos.https.html
- encrypted-media/drm-mp4-playback-temporary-setMediaKeys-immediately.https.html
- encrypted-media/clearkey-mp4-playback-temporary.https.html
- encrypted-media/drm-mp4-playback-temporary-waitingforkey.https.html
- encrypted-media/clearkey-mp4-playback-temporary-setMediaKeys-after-update.https.html
- encrypted-media/drm-mp4-playback-temporary-multisession.https.html
- encrypted-media/clearkey-mp4-playback-temporary-setMediaKeys-immediately.https.html
- encrypted-media/clearkey-mp4-setmediakeys-again-after-playback.https.html
- encrypted-media/drm-mp4-playback-temporary-setMediaKeys-onencrypted.https.html
- encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted.https.html
- encrypted-media/drm-mp4-playback-temporary-events.https.html
- html/semantics/embedded-content/media-elements/ready-states/autoplay.html
- html/semantics/embedded-content/media-elements/event_pause_noautoplay.html
- html/semantics/embedded-content/media-elements/audio_loop_base.html
- html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
- html/semantics/embedded-content/media-elements/paused_true_during_pause.html
- html/semantics/embedded-content/media-elements/video_loop_base.html
- html/semantics/embedded-content/media-elements/event_play_noautoplay.html
- html/semantics/embedded-content/media-elements/track/track-element/track-cues-sorted-before-dispatch.html
- html/semantics/embedded-content/media-elements/track/track-element/track-remove-active-cue.html
- html/semantics/embedded-content/media-elements/track/track-element/track-disabled-addcue.html
- html/semantics/embedded-content/media-elements/track/track-element/track-disabled.html
- html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-duration.html
- html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-exit.html
- html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html
- html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-timestamp-events.html
- html/semantics/embedded-content/media-elements/track/track-element/track-cues-missed.html
- html/semantics/embedded-content/media-elements/track/track-element/track-mode.html
- html/semantics/embedded-content/media-elements/track/track-element/track-remove-insert-ready-state.html
- html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-empty-cue.html
- html/semantics/embedded-content/media-elements/interfaces/TextTrack/cues.html
- html/semantics/embedded-content/media-elements/event_playing_noautoplay.html
- html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document.html
- html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-to-other-document.html
- html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document-networkState.html
- html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-within-document.html

</details>