### PR TITLE
Document maintenance procedure for invalid data

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,24 @@ Guidelines for issue reports and pull requests are included in this project’s 
   - The issue is a request that is deemed “out of scope” for the project.
   - The issue contains content that violates the [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Managing Results Data
+
+*Note: A new results reporting system is under development, so the following instructions are subject to change.*
+
+In order to improve throughput and limit the impact of intermittent failure, this project subdivides the task of collecting web-platform-tests results. It does this by using the "chunking" functionality of the WPT CLI, splitting the entire test suite into a number of segments and executing the segments in parallel. Once all segments are complete, the build master consolidates the results, uploads them to a central storage location, and notifies a database server of the new data.
+
+Although the system is designed to detect incomplete results and abort the upload process, unexpected errors may allow such invalid datasets to be reported. In this event, maintainers should take the following actions:
+
+1. Create a ticket in this project's issue tracker to describe the error
+2. Update the database record describing the faulty dataset by modifying the
+   `BrowserName` field according to the following pattern:
+
+       invalid-{{browser name}}-{{ticket reference}}
+
+   For instance, to annotate an invalid data set for the "experimental" version of the Firefox browser, referencing ticket 345 on GitHub.com, the `BrowserName` filed should be renamed to:
+
+       invalid-firefox-experimental-gh-345
+
 ## Reviewing Pull Requests
 
 Maintainers should review and post comments on pull requests within 3 business days. There is no guaranteed time box for pull requests to be closed with or without merge; however, make an effort to do so in a reasonable time frame.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,13 +22,13 @@ In order to improve throughput and limit the impact of intermittent failure, thi
 
 Although the system is designed to detect incomplete results and abort the upload process, unexpected errors may allow such invalid datasets to be reported. In this event, maintainers should take the following actions:
 
-1. Create a ticket in this project's issue tracker to describe the error
+1. Create an issue in this project's issue tracker to describe the error
 2. Update the database record describing the faulty dataset by modifying the
    `BrowserName` field according to the following pattern:
 
-       invalid-{{browser name}}-{{ticket reference}}
+       invalid-{{browser name}}-{{issue reference}}
 
-   For instance, to annotate an invalid data set for the "experimental" version of the Firefox browser, referencing ticket 345 on GitHub.com, the `BrowserName` filed should be renamed to:
+   For instance, to annotate an invalid data set for the "experimental" version of the Firefox browser, referencing issue 345 on GitHub.com, the `BrowserName` filed should be renamed to:
 
        invalid-firefox-experimental-gh-345
 


### PR DESCRIPTION
This is based on [a recent discussion in the wpt.fyi project](https://github.com/web-platform-tests/wpt.fyi/issues/110). I modified the proposal slightly, making "incomplete" a prefix for invalid TestResult names. This is because GQL does not support string pattern matching, but it does support comparison. We can filter with conditions like:

    BrowserName > 'invalid-' AND BrowserName < 'invalid-z'

A dedicated boolean field would be a far more natural way to model this information, but I'd like to limit the amount of change we make to the soon-to-be-decommissioned system.