### PR TITLE
Include "labels" in payload sent to new receiver

### DIFF
--- a/src/master/master.cfg
+++ b/src/master/master.cfg
@@ -296,6 +296,7 @@ upload_factory = util.BuildFactory([
                                  'upload-wpt-results.py',
                                  '--raw-results-directory', chunk_result_dir_name,
                                  '--product', util.Property('browser_name'),
+                                 '--browser-channel', util.Property('browser_channel'),
                                  '--browser-version', util.Property('browser_version'),
                                  '--os', util.Property('os_name'),
                                  '--os-version', util.Property('os_version'),

--- a/src/scripts/upload-wpt-results.py
+++ b/src/scripts/upload-wpt-results.py
@@ -17,8 +17,9 @@ import requests
 import tempfile
 
 
-def main(raw_results_directory, product, browser_version, os_name, os_version,
-         url, user_name, secret, override_platform, total_chunks):
+def main(raw_results_directory, product, browser_channel, browser_version,
+         os_name, os_version, url, user_name, secret, override_platform,
+         total_chunks):
     '''Consolidate the WPT results data into a single JSON file and upload to
     the WPT results receiver.
 
@@ -82,6 +83,9 @@ def main(raw_results_directory, product, browser_version, os_name, os_version,
         response = requests.post(
             url,
             auth=(user_name, secret),
+            # `labels` is a comma-separated string. Runners may add arbitrary
+            # labels.
+            data={'labels': browser_channel},
             files={'result_file': open(filename, 'rb')}
         )
 
@@ -146,6 +150,9 @@ def consolidate(raw_results_files):
 parser = argparse.ArgumentParser(description=main.__doc__)
 parser.add_argument('--raw-results-directory', required=True)
 parser.add_argument('--product', required=True)
+parser.add_argument('--browser-channel',
+                    choices=('stable', 'experimental'),
+                    required=True)
 parser.add_argument('--browser-version', required=True)
 parser.add_argument('--os', dest='os_name', required=True)
 parser.add_argument('--os-version', required=True)


### PR DESCRIPTION
This is intended to resolve gh-572. @Hexcles I believe that this extension is only relevant for the new results receiver. Is that right? Or should I amend this patch with an enhancement for the `wpt-legacy-wpt-results.py`?