### PR TITLE
Remove unnecessary property

### DIFF
--- a/src/master/master.cfg
+++ b/src/master/master.cfg
@@ -161,14 +161,7 @@ trigger_factory = util.BuildFactory(
         steps.Git(repourl='git://github.com/w3c/web-platform-tests',
                   shallow=True,
                   mode='full',
-                  method='clobber'),
-        # The commit date is required by the external web service which is
-        # notified when new result sets are available online. That information
-        # is captured by this builder so that the worker responsible for
-        # reporting does not need a local copy of the WPT repository.
-        steps.SetPropertyFromCommand(name='Retrieve commit date of latest revision',
-                                     command=['git', 'log', '-1', '--format=%cd', '--date=iso-strict'],
-                                     property='revision_date')
+                  method='clobber')
     ] +
     locate_steps +
     chunked_steps
@@ -255,7 +248,6 @@ chunked_factory = util.BuildFactory([
                               'browser_version': util.Property('browser_version'),
                               'os_name': util.Property('os_name'),
                               'os_version': util.Property('os_version'),
-                              'revision_date': util.Property('revision_date'),
                               'total_chunks': util.Property('total_chunks'),
                               'use_sauce_labs': util.Property('use_sauce_labs')
                           })

--- a/src/master/wpt_chunked_step.py
+++ b/src/master/wpt_chunked_step.py
@@ -25,7 +25,6 @@ class WPTChunkedStep(steps.Trigger):
         browser_url = self.build.properties.getProperty(
             'browser_url_%s_%s' % (browser_name, browser_channel)
         )
-        revision_date = self.build.properties.getProperty('revision_date')
 
         for scheduler in self.schedulerNames:
             unimportant = scheduler in self.unimportantSchedulerNames
@@ -43,8 +42,7 @@ class WPTChunkedStep(steps.Trigger):
                         'browser_url': browser_url,
                         'os_name': self.platform['os_name'],
                         'os_version': self.platform['os_version'],
-                        'use_sauce_labs': self.platform.get('sauce', False),
-                        'revision_date': revision_date
+                        'use_sauce_labs': self.platform.get('sauce', False)
                     },
                     'unimportant': unimportant
                 })


### PR DESCRIPTION
The legacy results receiver required the date of the git revision under
test. Since this project no longer interfaces with that receiver, the
date no longer need to be tracked internally.