### PR TITLE
Enable MojoJS when testing Chrome

### DIFF
--- a/src/master/wpt_run_step.py
+++ b/src/master/wpt_run_step.py
@@ -91,7 +91,8 @@ class WptRunStep(steps.ShellCommand):
             # Chrome to call getUserMedia without failing out.
             command.extend([
                 '--binary-arg=--use-fake-ui-for-media-stream',
-                '--binary-arg=--use-fake-device-for-media-stream'
+                '--binary-arg=--use-fake-device-for-media-stream',
+                '--binary-arg=--enable-blink-features=MojoJS,MojoJSTest'
             ])
 
             if properties.getProperty('browser_channel') == 'experimental':


### PR DESCRIPTION
Fixes #81 

This is the only missing requirement to run WebUSB tests on Chrome (as confirmed in https://crbug.com/821496#c19). WebUSB has a public test API interface but the fake device relies on browser-specific implementation (in Chrome's case, Mojo JS); also see this [comment](https://crbug.com/821496#c8).

@foolip , I'd like your stamp for this as it'd introduce yet another difference between wpt.fyi and running `wpt run` directly (similar to what we've already done for media stream).
@jugglinmike , PTAL if I missed anything.