### PR TITLE
Update Mozilla Geckodriver

### DIFF
--- a/provisioning/configuration/roles/web-browsers/tasks/main.yml
+++ b/provisioning/configuration/roles/web-browsers/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: Download Mozilla Geckodriver
   get_url:
-    url: https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+    url: https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
     dest: ~/downloads/
 
 - name: Extend hosts file with configuration to shunt Firefox requests

--- a/provisioning/configuration/roles/web-browsers/tasks/main.yml
+++ b/provisioning/configuration/roles/web-browsers/tasks/main.yml
@@ -70,7 +70,7 @@
 
 - name: Install Mozilla Geckodriver
   unarchive:
-    url: ~/downloads/geckodriver-v0.21.0-linux64.tar.gz
+    src: ~/downloads/geckodriver-v0.21.0-linux64.tar.gz
     dest: /usr/local/bin
     remote_src: true
 

--- a/provisioning/configuration/roles/web-browsers/tasks/main.yml
+++ b/provisioning/configuration/roles/web-browsers/tasks/main.yml
@@ -70,7 +70,7 @@
 
 - name: Install Mozilla Geckodriver
   unarchive:
-    src: ~/downloads/geckodriver-v0.19.1-linux64.tar.gz
+    url: ~/downloads/geckodriver-v0.21.0-linux64.tar.gz
     dest: /usr/local/bin
     remote_src: true
 


### PR DESCRIPTION
Version 0.21.0 of Mozilla Geckodriver was released on June 15, 2018 [1].
Update this project's provisioning scripts to install that version as
per [2].

[1] https://github.com/mozilla/geckodriver/releases/tag/v0.21.0
[2] https://github.com/web-platform-tests/wpt.fyi/issues/373