### PR TITLE
Integrate with wpt.fyi "revision announcer"

### DIFF
--- a/provisioning/configuration/roles/buildbot-master/tasks/main.yml
+++ b/provisioning/configuration/roles/buildbot-master/tasks/main.yml
@@ -179,3 +179,9 @@
     src: ../../src/scripts/upload-wpt-results.py
     dest: /usr/local/bin/upload-wpt-results.py
     mode: 0755
+
+- name: Install script for selecting WPT revision
+  copy:
+    src: ../../src/scripts/get-wpt-revision.py
+    dest: /usr/local/bin/get-wpt-revision.py
+    mode: 0755

--- a/src/master/master.cfg
+++ b/src/master/master.cfg
@@ -124,17 +124,29 @@ c['schedulers'] = [
   schedulers.Nightly(name='Daily (remote builds)',
                      builderNames=['Chunk Initiator'],
                      onlyIfChanged=False,
-                     properties={'remote': True, 'worker_os': 'linux'},
+                     properties={
+                         'interval': 'daily',
+                         'remote': True,
+                         'worker_os': 'linux'
+                     },
                      hour=[12]),
   schedulers.Nightly(name='Four times per day (local GNU/Linux builds)',
                      builderNames=['Chunk Initiator'],
                      onlyIfChanged=False,
-                     properties={'remote': False, 'worker_os': 'linux'},
+                     properties={
+                         'interval': 'four_hourly',
+                         'remote': False,
+                         'worker_os': 'linux'
+                     },
                      hour=[0, 6, 12, 18]),
   schedulers.Nightly(name='Semi-daily (local macOS builds)',
                      builderNames=['Chunk Initiator'],
                      onlyIfChanged=False,
-                     properties={'remote': False, 'worker_os': 'macos'},
+                     properties={
+                         'interval': 'eight_hourly',
+                         'remote': False,
+                         'worker_os': 'macos'
+                     },
                      hour=[0, 12])
 ]
 
@@ -205,18 +217,29 @@ for spec_id, spec in platform_manifest.iteritems():
                                         platform_id=spec_id,
                                         platform=spec,
                                         doStepIf=doStepIf,
+                                        sourceStamp={
+                                            # The `codebase` property must be
+                                            # set in order for this build step
+                                            # to function. It is currently
+                                            # undocumented:
+                                            # https://github.com/buildbot/buildbot/issues/4281
+                                            'codebase': u'',
+                                            'branch': None,
+                                            'repository': u'',
+                                            'revision': util.Property('announced_revision')
+                                        },
                                         total_chunks=total_chunks))
 
 trigger_factory = util.BuildFactory(
     [
-        # Fetch the latest version of `master` prior to triggering chunked
+        # Query the wpt.fyi "revision announcer" prior to triggering chunked
         # runs.  This ensures that the all chunks use the same revision of WPT
         # (by setting the Buildbot property named `revision`), including when
         # failed builds are manually re-tried via the web interface.
-        steps.Git(repourl='git://github.com/w3c/web-platform-tests',
-                  shallow=True,
-                  mode='full',
-                  method='clobber')
+        steps.SetPropertyFromCommand(name='Identify revision',
+                                     command=['get-wpt-revision.py', util.Property('interval')],
+                                     property='announced_revision',
+                                     haltOnFailure=True)
     ] +
     locate_steps +
     chunked_steps

--- a/src/scripts/get-wpt-revision.py
+++ b/src/scripts/get-wpt-revision.py
@@ -46,7 +46,7 @@ def main(interval):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=main.__doc__)
     parser.add_argument('interval',
-                        choices=('daily', 'eight_hourly', 'four_hourly',
-                                 'hourly', 'two_hourly', 'weekly'))
+                        choices=('hourly', 'two_hourly', 'four_hourly',
+                                 'eight_hourly', 'daily', 'weekly'))
 
     print main(**vars(parser.parse_args()))

--- a/src/scripts/get-wpt-revision.py
+++ b/src/scripts/get-wpt-revision.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The WPT Dashboard Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import contextlib
+import httplib
+import json
+import urlparse
+
+
+@contextlib.contextmanager
+def request(method, url):
+    parts = urlparse.urlparse(url)
+    if parts.scheme == 'https':
+        Connection = httplib.HTTPSConnection
+    else:
+        Connection = httplib.HTTPConnection
+    conn = Connection(parts.netloc)
+    path = parts.path
+    if parts.query:
+        path += '?%s' % parts.query
+
+    headers = {'User-Agent': 'wpt-results-collector'}
+
+    conn.request(method, path, headers=headers)
+
+    yield conn.getresponse()
+
+    conn.close()
+
+
+def main(interval):
+    '''Query the wpt.fyi "revision announcer" for the latest revision of
+    interest as published at the specified interval. Documentation available
+    online at https://github.com/web-platform-tests/wpt.fyi/'''
+
+    with request('GET', 'https://wpt.fyi/api/revisions/latest') as response:
+        data = json.loads(response.read())
+
+    return data['revisions'][interval]['hash']
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument('interval',
+                        choices=('daily', 'eight_hourly', 'four_hourly',
+                                 'hourly', 'two_hourly', 'weekly'))
+
+    print main(**vars(parser.parse_args()))


### PR DESCRIPTION
## Description

Retrieve revisions of WPT in which to run tests from the wpt.fyi "revision announcer."

## Review Information

No change in operation.

## Changes

This should resolve gh-591.

## Requirements

This change introduces no new dependencies.