### PR TITLE
Opt-out of "headless" mode

### DIFF
--- a/src/master/wpt_run_step.py
+++ b/src/master/wpt_run_step.py
@@ -95,7 +95,10 @@ class WptRunStep(steps.ShellCommand):
             command.extend([
                 '--webdriver-binary',
                 properties.getProperty('webdriver_binary'),
-                '--install-fonts'
+                '--install-fonts',
+                # The authenticity of results collected in "headless" mode is
+                # disputed.
+                '--no-headless'
             ])
 
             browser_id = browser_name


### PR DESCRIPTION
As of [1] (merged on 2018-09-24), the WPT CLI enables the "headless"
mode of Chrome and Firefox by default. This mode is more convenient for
contributors running the tests from their development system, but it
also relies on functionality which is not enabled during typical usage
of the browsers.  Results collected in this mode are therefore less
authentic than results collected using a virtual display.

@jgraham commented on this in [2]:

> unless we have some reasonable assurance that headless mode matches
> non-headless in all cases (e.g. the relevant browser running both
> configurations in CI with identical results) I don't think we should
> enable it for wpt.fyi-ingested runs.

That issue includes evidence that the results are not equivalent,
meaning "headless" mode is not appropriate for publicly documenting the
capabilities of each browser.

Extend the results collection system to use the new `--no-headless`
command-line argument.

[1] https://github.com/web-platform-tests/wpt/pull/13076
[2] https://github.com/web-platform-tests/results-collection/issues/603