### PR TITLE
Ignore Safari Technology Preview version 66

### DIFF
--- a/src/scripts/get-binary-url.py
+++ b/src/scripts/get-binary-url.py
@@ -17,6 +17,13 @@ import tempfile
 import urlparse
 import urllib
 
+MIRRORED_STP_65 = ('https://storage.googleapis.com/' +
+                   'browsers/safari-experimental-macos/' +
+                   'dddf60d868e067107eea7585b22b193c')
+MIRRORED_STP_66_BROKEN = ('https://storage.googleapis.com/' +
+                          'browsers/safari-experimental-macos/' +
+                          'd646aa325414b596b677ee4aafeca455')
+
 
 def main(browser_name, channel, application, os_name, bucket_name):
     '''Find the most recent build of a given browser or WebDriver server and
@@ -84,6 +91,16 @@ def main(browser_name, channel, application, os_name, bucket_name):
     assert url is not None
 
     logger.info('Mirrored version found at %s', url)
+
+    # Safari Technology Preview version 66 has a known bug which prevents
+    # automation. Use version 65 until a new version is published. This script
+    # will receive the fix even if it is published as "Safari Technology
+    # Preview 66" because it operates on the etag header value.
+    #
+    # https://github.com/web-platform-tests/results-collection/issues/609
+    if url == MIRRORED_STP_66_BROKEN:
+        logger.info('Using Safari Technology Preview 65 instead of 66')
+        url = MIRRORED_STP_65
 
     return url
 


### PR DESCRIPTION
@foolip [We collected results from Safari Technology Preview yesterday](https://wpt.fyi/results/?sha=ee2e69bfb1&labels=experimental), but that was accomplished by renaming the binary for STP 66 in the project's Google Cloud Storage bucket. Though heinous in its own right, this change is slightly better because it doesn't rely on intentionally-misnamed assets.

This is a short-term fix for gh-609