### PR TITLE
Collect results from stable Safari locally

### DIFF
--- a/provisioning/configuration/roles/buildbot-worker/tasks/darwin.yml
+++ b/provisioning/configuration/roles/buildbot-worker/tasks/darwin.yml
@@ -35,11 +35,19 @@
       end tell
     ' | osascript -
 
-- name: Install script for enabling remote automation in Safari
+- name: Install scripts for administering Safari
   copy:
-    src: ../../src/scripts/safari-enable-automation.sh
+    src: '{{item}}'
     dest: /usr/local/bin/
     mode: 0755
+  with_items:
+    - ../../src/scripts/safari-enable-automation.sh
+    - ../../src/scripts/safari-disable-popup-blocker.sh
+
+- name: Allow application user to enable remote automation in Safari
+  lineinfile:
+    dest: /etc/sudoers
+    line: '{{application_user}} ALL=(ALL) NOPASSWD: /usr/local/bin/safari-enable-automation.sh'
 
 # https://discussions.apple.com/thread/8200117
 - name: Disable Spotlight

--- a/src/master/browsers.json
+++ b/src/master/browsers.json
@@ -47,6 +47,14 @@
         "os_version": "10.13",
         "remote": true
     },
+    "safari-11.1-macos-10.13": {
+        "browser_name": "safari",
+        "browser_channel": "stable",
+        "browser_version": null,
+        "os_name": "macos",
+        "os_version": "10.13",
+        "remote": false
+    },
     "safari-technology-preview": {
         "browser_name": "safari",
         "browser_channel": "experimental",

--- a/src/master/browsers.json
+++ b/src/master/browsers.json
@@ -47,7 +47,7 @@
         "os_version": "10.13",
         "remote": true
     },
-    "safari-11.1-macos-10.13": {
+    "safari-stable-macos": {
         "browser_name": "safari",
         "browser_channel": "stable",
         "browser_version": null,

--- a/src/master/master.cfg
+++ b/src/master/master.cfg
@@ -116,6 +116,11 @@ def render_chunked_builder(properties):
 
     return ['GNU/Linux Chunked Runner']
 
+@util.renderer
+def is_local_safari(properties):
+    return (properties.getProperty('browser_name') == 'safari' and
+            not properties.getProperty('use_sauce_labs'))
+
 c['schedulers'] = [
   schedulers.Triggerable(name='chunked',
                          builderNames=render_chunked_builder),
@@ -141,15 +146,15 @@ c['schedulers'] = [
                      },
                      hour=[0, 6, 12, 18],
                      minute=[5]),
-  schedulers.Nightly(name='Semi-daily (local macOS builds)',
+  schedulers.Nightly(name='Daily (local macOS builds)',
                      builderNames=['Chunk Initiator'],
                      onlyIfChanged=False,
                      properties={
-                         'interval': 'twelve_hourly',
+                         'interval': 'daily',
                          'remote': False,
                          'worker_os': 'macos'
                      },
-                     hour=[0, 12],
+                     hour=[0],
                      minute=[5])
 ]
 
@@ -172,8 +177,10 @@ for spec_id, spec in platform_manifest.iteritems():
     doStepIf = partial(filter_build, spec.get('os_name'), spec.get('remote'))
     browser_name = spec.get('browser_name')
     browser_channel = spec.get('browser_channel')
+    is_safari_stable = browser_name == 'safari' and browser_channel == 'stable'
+    should_install_browser = not spec.get('remote') and not is_safari_stable
 
-    if not spec.get('remote'):
+    if should_install_browser:
         name=str('Find installer for %s@%s' % (browser_name, browser_channel))
         locate_steps.append(
             steps.SetPropertyFromCommand(name=name,
@@ -302,7 +309,11 @@ chunked_factory = util.BuildFactory(
     steps.ShellCommand(name='Trust the root certificate',
                        command=['sudo', 'trust-root-ca.sh', './tools/certs/cacert.pem'],
                        haltOnFailure=True,
-                       doStepIf=lambda step: step.build.properties.getProperty('workername') in workernames_macos),
+                       doStepIf=is_local_safari),
+    steps.ShellCommand(name='Disable macOS popup blocker',
+                       command=['safari-disable-popup-blocker.sh'],
+                       haltOnFailure=True,
+                       doStepIf=is_local_safari),
     steps.SetProperties(properties={
                             'log_wptreport': temp_dir.prefix('report.json'),
                             'log_raw': temp_dir.prefix('log-raw.txt'),
@@ -315,6 +326,11 @@ chunked_factory = util.BuildFactory(
                                           util.Property('browser_url')],
                                  haltOnFailure=True,
                                  doStepIf=lambda step: step.build.properties.getProperty('browser_url')),
+    steps.SetProperty(property='browser_binary',
+                      value='/Applications/Safari.app/Contents/MacOS/Safari',
+                      doStepIf=lambda step: (is_local_safari.getRenderingFor(step.build.properties) and
+                                             step.build.properties.getProperty('browser_channel') == 'stable'),
+                      hideStepIf=True),
     steps.SetPropertyFromCommand(name=util.Interpolate('Install %(prop:browser_name)s WebDriver'),
                                  property='webdriver_binary',
                                  command=['install-webdriver.sh',
@@ -322,10 +338,12 @@ chunked_factory = util.BuildFactory(
                                           util.Property('webdriver_url')],
                                  haltOnFailure=True,
                                  doStepIf=lambda step: step.build.properties.getProperty('webdriver_url')),
-    steps.SetProperty(property='webdriver_binary',
-                      hideStepIf=True,
-                      value='/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver',
-                      doStepIf=lambda step: step.build.properties.getProperty('browser_name') == 'safari'),
+    steps.SetPropertyFromCommand(name='Enable remote automation in Apple Safari',
+                                 property='webdriver_binary',
+                                 command=['sudo', 'safari-enable-automation.sh',
+                                          util.Property('browser_channel')],
+                                 haltOnFailure=True,
+                                 doStepIf=is_local_safari),
     steps.SetPropertyFromCommand(name='Read browser version',
                                  property='browser_version',
                                  command=['read-browser-version.py',
@@ -334,7 +352,7 @@ chunked_factory = util.BuildFactory(
                                           '--binary',
                                           util.Property('browser_binary')],
                                  haltOnFailure=True,
-                                 doStepIf=lambda step: step.build.properties.getProperty('browser_url')),
+                                 doStepIf=lambda step: step.build.properties.getProperty('browser_binary')),
     # Reference: "Long-running Chromedriver process"
     # https://github.com/web-platform-tests/results-collection/issues/547
     steps.ShellCommand(name='Ensure port availability',

--- a/src/scripts/install-browser.sh
+++ b/src/scripts/install-browser.sh
@@ -73,8 +73,6 @@ install_safari_technology_preview() {
     return 1
   fi
 
-  safari-enable-automation.sh >&2 || return 1
-
   echo "${application_dir}/Contents/MacOS/Safari Technology Preview"
 }
 

--- a/src/scripts/safari-disable-popup-blocker.sh
+++ b/src/scripts/safari-disable-popup-blocker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+max_wait=10
+
+if ! defaults read com.apple.Safari > /dev/null 2>&1; then
+  echo Application defaults are not present, so modifications would be
+  echo over-written when the application is next run. Starting the application
+  echo in order to initialize defaults.
+
+  /Applications/Safari.app/Contents/MacOS/Safari &
+
+  safari_pid=$!
+
+  count=0
+  while ! defaults read com.apple.Safari > /dev/null 2>&1; do
+    sleep 1
+    count=$((count + 1))
+
+    if [ $count -gt $max_wait ]; then
+      echo Error: defaults not written after $max_wait seconds >&2
+      exit 1
+    fi
+  done
+
+  echo Application defaults created. Terminating process.
+
+  kill -9 $safari_pid
+fi
+
+# source:
+# https://github.com/web-platform-tests/wpt/blob/1999770b55cb8cdd93dbce0e78e5c94b2ba22e0e/tools/wptrunner/wptrunner/browsers/sauce_setup/safari-prerun.sh
+defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaScriptCanOpenWindowsAutomatically -bool true
+
+echo Closing all instances of the application to ensure the changes
+echo are observed.
+
+killall -9 Safari || true


### PR DESCRIPTION
This project was previously extended with support for collecting results
from Apple Safari Technology Preview via a worker running on a macOS
system. Extend the system to also support the stable release of Apple
Safari.

Previously, a single build step installed Safari Technology Preview and
enabled remote automation. Because the stable release of Safari is
bundled with the operating system, it cannot be installed. It does
require explicit enabling of remote automation, however. Refactor the
two operations into distinct build steps in order to support both
browsers.

Safari Technology Preview enables the "Develop" UI menu by default, so
the automation script could interact with it immediately. The menu is
not present in the default configuration of Safari. Add logic to ensure
the menu is available.

This project already included logic to determine whether automation had
successfully been enabled in Safari. That logic assumed the browser
implemented the W3C WebDriver protocol, but the stable release of Safari
does not. Extend the script to support both

This change is not supported by additional infrastructure. Decrease the
rate of collection in order to avoid over-utilizing available workers.

---

@foolip I know you're not too familiar with Buildbot internals, but I thought
you might be interested in seeing exactly how automation differs between Safari
stable and Safari Technology Preview.

I've vetted this change by deploying it to the results-collection staging
server last week. It's uploaded results from Safari's stable release a number
of times, though this is hard to recognize on wpt.fyi since we're also using
Sauce Labs to collect from Safari stable. It's easier see in [the most recent
upload](https://wpt.fyi/results/?sha=ee2e69bfb1&labels=stable) since I updated
to Safari 12 over the weekend (Sauce Labs has yet to support that release).

