### PR TITLE
Remove Safari 11.1

### DIFF
--- a/src/master/browsers.json
+++ b/src/master/browsers.json
@@ -39,14 +39,6 @@
         "os_version": "*",
         "remote": false
     },
-    "safari-11.1-macos-10.13-sauce": {
-        "browser_name": "safari",
-        "browser_channel": "stable",
-        "browser_version": "11.1",
-        "os_name": "macos",
-        "os_version": "10.13",
-        "remote": true
-    },
     "safari-stable-macos": {
         "browser_name": "safari",
         "browser_channel": "stable",


### PR DESCRIPTION
This project now collects results from Safari 12 via an
internally-managed macOS system. Results from that release are more
relevant to this project, so the overhead of maintaining integration
with the Safari 11.1 browser offered by Sauce Labs is no longer
justified.

Update the configuration so that the Buildbot build master no longer
creates jobs for Safari 11.1 via Sauce Labs.