### PR TITLE
Turn Server-Timing experimental feature on

### DIFF
--- a/src/scripts/safari-disable-popup-blocker.sh
+++ b/src/scripts/safari-disable-popup-blocker.sh
@@ -31,6 +31,9 @@ fi
 # https://github.com/web-platform-tests/wpt/blob/1999770b55cb8cdd93dbce0e78e5c94b2ba22e0e/tools/wptrunner/wptrunner/browsers/sauce_setup/safari-prerun.sh
 defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaScriptCanOpenWindowsAutomatically -bool true
 
+# turn on experimental features
+defaults write com.apple.Safari ExperimentalServerTimingEnabled -bool true
+
 echo Closing all instances of the application to ensure the changes
 echo are observed.
 


### PR DESCRIPTION
I'm attempting to improve the [server-timing results](https://wpt.fyi/results/server-timing) on Safari.

![image](https://user-images.githubusercontent.com/9857665/47683954-3927e900-db9f-11e8-9618-6ba2589ea7ea.png)

I will remove this if/when Safari enables this by default. 