### PR TITLE
Tolerate temporary unavailability of wpt.fyi

### DIFF
--- a/src/master/master.cfg
+++ b/src/master/master.cfg
@@ -255,7 +255,12 @@ trigger_factory = util.BuildFactory(
         # (by setting the Buildbot property named `revision`), including when
         # failed builds are manually re-tried via the web interface.
         steps.SetPropertyFromCommand(name='Identify revision',
-                                     command=['get-wpt-revision.py', util.Property('interval')],
+                                     command=[
+                                         'get-wpt-revision.py',
+                                         '--retry-interval', '60',
+                                         '--retry-timeout', '600',
+                                         util.Property('interval')
+                                     ],
                                      property='announced_revision',
                                      haltOnFailure=True)
     ] +

--- a/src/scripts/get-wpt-revision.py
+++ b/src/scripts/get-wpt-revision.py
@@ -8,7 +8,12 @@ import argparse
 import contextlib
 import httplib
 import json
+import logging
+import time
 import urlparse
+
+
+logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -32,17 +37,42 @@ def request(method, url):
     conn.close()
 
 
-def main(interval):
+@contextlib.contextmanager
+def get_with_retry(url, interval, timeout):
+    try:
+        with request('GET', url) as response:
+            status = response.status
+            message = 'HTTP Error %s: %s' % (status, response.reason)
+
+            if status >= 200 and status < 300:
+                yield response
+                return
+    except Exception as exception:
+        message = str(exception)
+
+    remaining = timeout - interval
+
+    if remaining <= 0:
+        logger.warn('Retry timeout exceeded.')
+        raise Exception(message)
+
+    logging.warn(message)
+    logging.warn('Retrying in %s seconds...' % (interval,))
+
+    time.sleep(interval)
+
+    with request_with_retry(method, url, interval, remaining) as response:
+        yield response
+
+
+def main(interval, retry_interval, retry_timeout):
     '''Query the wpt.fyi "revision announcer" for the latest revision of
     interest as published at the specified interval. Documentation available
     online at https://github.com/web-platform-tests/wpt.fyi/'''
 
-    with request('GET', 'https://wpt.fyi/api/revisions/latest') as response:
-        if response.status < 200 or response.status >= 300:
-            raise Exception(
-                'HTTP Error %s: %s' % (response.status, response.reason)
-            )
+    url = 'https://wpt.fyi/api/revisions/latest'
 
+    with get_with_retry(url, retry_interval, retry_timeout) as response:
         body = response.read()
 
         try:
@@ -64,6 +94,18 @@ def main(interval):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument('--retry-interval',
+                        type=int,
+                        default=60,
+                        help='''Duration in seconds to wait between retrying
+                            failed requests to wpt.fyi'''
+                        )
+    parser.add_argument('--retry-timeout',
+                        type=int,
+                        default=60 * 1000,
+                        help='''Duration in seconds to wait before cancelling
+                            attempts to retry failed requests'''
+                        )
     parser.add_argument('interval',
                         choices=('hourly', 'two_hourly', 'six_hourly',
                                  'twelve_hourly', 'daily', 'weekly'))

--- a/src/scripts/get-wpt-revision.py
+++ b/src/scripts/get-wpt-revision.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
                         )
     parser.add_argument('--retry-timeout',
                         type=int,
-                        default=60 * 1000,
+                        default=60 * 10,
                         help='''Duration in seconds to wait before cancelling
                             attempts to retry failed requests'''
                         )

--- a/src/scripts/get-wpt-revision.py
+++ b/src/scripts/get-wpt-revision.py
@@ -61,7 +61,7 @@ def get_with_retry(url, interval, timeout):
 
     time.sleep(interval)
 
-    with request_with_retry(method, url, interval, remaining) as response:
+    with get_with_retry(url, interval, remaining) as response:
         yield response
 
 


### PR DESCRIPTION
This project recently experienced a failure because wpt.fyi was
temporarily unavailable [1]. It has since been confirmed that
intermittent outages are expected [2], so the system should tolerate the
condition by retrying failed requests for a short period.

[1] https://github.com/web-platform-tests/results-collection/issues/632
[2] https://github.com/web-platform-tests/wpt.fyi/issues/802