### PR TITLE
Switch from testing Edge 17 to 18

### DIFF
--- a/src/master/browsers.json
+++ b/src/master/browsers.json
@@ -15,10 +15,10 @@
         "os_version": "*",
         "remote": false
     },
-    "edge-17-windows-10-sauce": {
+    "edge-18-windows-10-sauce": {
         "browser_name": "edge",
         "browser_channel": "stable",
-        "browser_version": "17",
+        "browser_version": "18",
         "os_name": "windows",
         "os_version": "10",
         "remote": true


### PR DESCRIPTION
Edge 44.17763.1.0 / EdgeHTML 18.17763 is available on Sauce Labs.

This is the latest stable version of Edge, and testing it will help validate
the setup for Edge on Azure Pipelines:
https://github.com/web-platform-tests/wpt/issues/14836